### PR TITLE
SLING-12573 Fix build for jdk17+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>43</version>
+        <version>46</version>
         <relativePath />
     </parent>
 
@@ -36,6 +36,7 @@
         <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
         <!-- To debug the pax process, override this with -D -->
         <pax.vm.options>-Xmx512M</pax.vm.options>
+        <project.build.outputTimestamp></project.build.outputTimestamp>
     </properties>
 
     <scm>
@@ -182,32 +183,14 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jmock</groupId>
-            <artifactId>jmock-junit4</artifactId>
-            <version>2.8.2</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
+            <version>5.14.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>3.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>1.6.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
-            <version>1.6.4</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
@@ -242,7 +225,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.paxexam</artifactId>
-            <version>3.1.0</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -276,6 +259,12 @@
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
             <version>7.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+            <version>3.5.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/apache/sling/auth/form/it/AuthFormClientTestSupport.java
+++ b/src/test/java/org/apache/sling/auth/form/it/AuthFormClientTestSupport.java
@@ -18,7 +18,8 @@
  */
 package org.apache.sling.auth.form.it;
 
-import static org.apache.sling.testing.paxexam.SlingOptions.slingScriptingSightly;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingScriptingHtl;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingBundleresource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -90,7 +91,8 @@ public abstract class AuthFormClientTestSupport extends AuthFormTestSupport {
 
         return new Option[]{
             // add sightly support for the test script
-            slingScriptingSightly(),
+            slingScriptingHtl(),
+            slingBundleresource(),
 
             // add the test script tinybundle
             bundle,

--- a/src/test/java/org/apache/sling/auth/form/it/AuthFormTestSupport.java
+++ b/src/test/java/org/apache/sling/auth/form/it/AuthFormTestSupport.java
@@ -86,6 +86,15 @@ public abstract class AuthFormTestSupport extends TestSupport {
             jacocoCommand = new VMOption(jacocoOpt);
         }
 
+        // SLING-12573 - Java 21 support was added in ASM 9.5
+        //   NOTE: remove this block when the versionResolver defaults to this version of asm* or later
+        versionResolver.setVersion("org.ow2.asm", "asm", "9.5");
+        versionResolver.setVersion("org.ow2.asm", "asm-analysis", "9.5");
+        versionResolver.setVersion("org.ow2.asm", "asm", "9.5");
+        versionResolver.setVersion("org.ow2.asm", "asm-commons", "9.5");
+        versionResolver.setVersion("org.ow2.asm", "asm-util", "9.5");
+        versionResolver.setVersion("org.ow2.asm", "asm-tree", "9.5");
+
         return options(
             composite(
                 super.baseConfiguration(),

--- a/src/test/java/org/apache/sling/auth/form/it/AuthFormTestSupport.java
+++ b/src/test/java/org/apache/sling/auth/form/it/AuthFormTestSupport.java
@@ -94,6 +94,11 @@ public abstract class AuthFormTestSupport extends TestSupport {
                 optionalRemoteDebug(),
                 slingQuickstart(),
                 testBundle("bundle.filename"),
+                // testing - ensure that the /content path is accessible to everyone
+                //   NOTE: required since update to o.a.sling.testing.paxexam 4.x as the 3.x version already did this step
+                factoryConfiguration("org.apache.sling.jcr.repoinit.RepositoryInitializer")
+                    .put("scripts", new String[]{"create path (sling:OrderedFolder) /content\nset ACL for everyone\n      allow   jcr:read    on /content\n  end"})
+                    .asOption(),
                 // testing - add a user to use to login and verify the content loading has happened
                 factoryConfiguration("org.apache.sling.jcr.repoinit.RepositoryInitializer")
                     .put("scripts", new String[] {


### PR DESCRIPTION
1. Bump the parent in the pom to a version that is compatible with jdk17
2. Migrate tests using powermock/easymock to mockito and "osgi mocks"
3. Bump the org.apache.sling.testing.paxexam dependency to 4.0.0 and related refactoring