### PR TITLE
SLING-12890 bump commons-lang3 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.0</version>
+            <version>3.18.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/java/org/apache/sling/auth/form/it/AuthFormTestSupport.java
+++ b/src/test/java/org/apache/sling/auth/form/it/AuthFormTestSupport.java
@@ -96,6 +96,10 @@ public abstract class AuthFormTestSupport extends TestSupport {
         versionResolver.setVersion("org.ow2.asm", "asm-util", "9.5");
         versionResolver.setVersion("org.ow2.asm", "asm-tree", "9.5");
 
+        // SLING-12890 - bump to a compatible version of commons-lang3
+        //  NOTE: remove this when the versionResolver defaults to this version or later
+        versionResolver.setVersionFromProject("org.apache.commons", "commons-lang3");
+
         return options(composite(
                         super.baseConfiguration(),
                         when(vmOption != null).useOptions(vmOption),


### PR DESCRIPTION
to resolve dependency warning about CVE-2025-48924