### PR TITLE
SLING-12957 migrate to Auth Core 2.x, Sling API 3.x and Jakarta Servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </parent>
 
     <artifactId>org.apache.sling.auth.form</artifactId>
-    <version>1.0.25-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Apache Sling Form Based Authentication</name>
     <description>Bundle implementing form based authentication with login
@@ -43,6 +43,7 @@
         <pax.vm.options>-Xmx512M</pax.vm.options>
         <project.build.outputTimestamp>2024-07-01T12:25:41Z</project.build.outputTimestamp>
         <sling.java.version>17</sling.java.version>
+        <slf4j.version>2.0.17</slf4j.version>
     </properties>
 
     <dependencies>
@@ -79,7 +80,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.auth.core</artifactId>
-            <version>1.4.2</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -96,7 +97,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.25.4</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -111,8 +112,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -160,6 +168,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -259,16 +268,10 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <systemProperties>
-                        <property>
-                            <name>bundle.filename</name>
-                            <value>${basedir}/target/${project.build.finalName}.jar</value>
-                        </property>
-                        <property>
-                            <name>pax.vm.options</name>
-                            <value>${pax.vm.options}</value>
-                        </property>
-                    </systemProperties>
+                    <systemPropertyVariables>
+                        <bundle.filename>${basedir}/target/${project.build.finalName}.jar</bundle.filename>
+                        <pax.vm.options>${pax.vm.options}</pax.vm.options>
+                    </systemPropertyVariables>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/org/apache/sling/auth/form/impl/AuthenticationFormServlet.java
+++ b/src/main/java/org/apache/sling/auth/form/impl/AuthenticationFormServlet.java
@@ -18,11 +18,10 @@
  */
 package org.apache.sling.auth.form.impl;
 
-import javax.servlet.Servlet;
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.sling.auth.core.spi.AbstractAuthenticationFormServlet;
-import org.apache.sling.auth.core.spi.AuthenticationHandler;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.sling.auth.core.spi.AbstractJakartaAuthenticationFormServlet;
+import org.apache.sling.auth.core.spi.JakartaAuthenticationHandler;
 import org.apache.sling.auth.form.FormReason;
 import org.osgi.service.component.annotations.Component;
 
@@ -37,7 +36,7 @@ import org.osgi.service.component.annotations.Component;
             "sling.servlet.paths=" + AuthenticationFormServlet.SERVLET_PATH,
             "service.description=Default Login Form for Form Based Authentication"
         })
-public class AuthenticationFormServlet extends AbstractAuthenticationFormServlet {
+public class AuthenticationFormServlet extends AbstractJakartaAuthenticationFormServlet {
 
     public static final String SERVLET_PATH = "/system/sling/form/login"; // NOSONAR
     public static final String AUTH_REQUIREMENTS = "-" + SERVLET_PATH;
@@ -57,12 +56,12 @@ public class AuthenticationFormServlet extends AbstractAuthenticationFormServlet
     @Override
     protected String getReason(final HttpServletRequest request) {
         // return the resource attribute if set to a non-empty string
-        Object resObj = request.getAttribute(AuthenticationHandler.FAILURE_REASON);
+        Object resObj = request.getAttribute(JakartaAuthenticationHandler.FAILURE_REASON);
         if (resObj instanceof FormReason formReason) {
             return formReason.toString();
         }
 
-        final String reason = request.getParameter(AuthenticationHandler.FAILURE_REASON);
+        final String reason = request.getParameter(JakartaAuthenticationHandler.FAILURE_REASON);
         if (reason != null) {
             try {
                 return FormReason.valueOf(reason).toString();

--- a/src/main/java/org/apache/sling/auth/form/impl/FormAuthenticationHandler.java
+++ b/src/main/java/org/apache/sling/auth/form/impl/FormAuthenticationHandler.java
@@ -20,12 +20,6 @@ package org.apache.sling.auth.form.impl;
 
 import javax.jcr.Credentials;
 import javax.jcr.SimpleCredentials;
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,6 +29,12 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.sling.api.auth.Authenticator;
 import org.apache.sling.api.resource.LoginException;
@@ -43,9 +43,9 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.auth.core.AuthConstants;
 import org.apache.sling.auth.core.AuthUtil;
-import org.apache.sling.auth.core.spi.AuthenticationHandler;
 import org.apache.sling.auth.core.spi.AuthenticationInfo;
-import org.apache.sling.auth.core.spi.DefaultAuthenticationFeedbackHandler;
+import org.apache.sling.auth.core.spi.DefaultJakartaAuthenticationFeedbackHandler;
+import org.apache.sling.auth.core.spi.JakartaAuthenticationHandler;
 import org.apache.sling.auth.form.FormReason;
 import org.apache.sling.auth.form.impl.jaas.FormCredentials;
 import org.apache.sling.auth.form.impl.jaas.JaasHelper;
@@ -69,11 +69,12 @@ import org.slf4j.LoggerFactory;
  */
 @Component(
         name = "org.apache.sling.auth.form.FormAuthenticationHandler",
-        property = {AuthenticationHandler.TYPE_PROPERTY + "=" + HttpServletRequest.FORM_AUTH},
-        service = AuthenticationHandler.class,
+        property = {JakartaAuthenticationHandler.TYPE_PROPERTY + "=" + HttpServletRequest.FORM_AUTH},
+        service = JakartaAuthenticationHandler.class,
         immediate = true)
 @Designate(ocd = FormAuthenticationHandlerConfig.class)
-public class FormAuthenticationHandler extends DefaultAuthenticationFeedbackHandler implements AuthenticationHandler {
+public class FormAuthenticationHandler extends DefaultJakartaAuthenticationFeedbackHandler
+        implements JakartaAuthenticationHandler {
 
     /**
      * The request method required for user name and password submission by the form
@@ -359,7 +360,7 @@ public class FormAuthenticationHandler extends DefaultAuthenticationFeedbackHand
         if (REQUEST_METHOD.equals(request.getMethod())
                 && request.getRequestURI().endsWith(REQUEST_URL_SUFFIX)) {
 
-            if (DefaultAuthenticationFeedbackHandler.handleRedirect(request, response)) {
+            if (DefaultJakartaAuthenticationFeedbackHandler.handleRedirect(request, response)) {
                 // terminate request, all done in the default handler
                 result = false;
             } else {

--- a/src/test/java/org/apache/sling/auth/form/impl/FormAuthenticationHandlerTest.java
+++ b/src/test/java/org/apache/sling/auth/form/impl/FormAuthenticationHandlerTest.java
@@ -18,12 +18,11 @@
  */
 package org.apache.sling.auth.form.impl;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.File;
 import java.util.Collections;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.sling.api.auth.Authenticator;
 import org.apache.sling.auth.core.spi.AuthenticationInfo;
 import org.apache.sling.testing.mock.osgi.MockBundle;

--- a/src/test/java/org/apache/sling/auth/form/it/AuthFormClientTestSupport.java
+++ b/src/test/java/org/apache/sling/auth/form/it/AuthFormClientTestSupport.java
@@ -19,7 +19,6 @@
 package org.apache.sling.auth.form.it;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.net.URI;
@@ -31,6 +30,7 @@ import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.List;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;

--- a/src/test/java/org/apache/sling/auth/form/it/SLING10290IT.java
+++ b/src/test/java/org/apache/sling/auth/form/it/SLING10290IT.java
@@ -18,12 +18,11 @@
  */
 package org.apache.sling.auth.form.it;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Date;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.cookie.Cookie;

--- a/src/test/java/org/apache/sling/auth/form/it/SLING10421InvalidDomainIT.java
+++ b/src/test/java/org/apache/sling/auth/form/it/SLING10421InvalidDomainIT.java
@@ -18,11 +18,10 @@
  */
 package org.apache.sling.auth.form.it;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 import java.util.Date;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/src/test/java/org/apache/sling/auth/form/it/SLING10421ValidDomainIT.java
+++ b/src/test/java/org/apache/sling/auth/form/it/SLING10421ValidDomainIT.java
@@ -18,11 +18,10 @@
  */
 package org.apache.sling.auth.form.it;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 import java.util.Date;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/src/test/resources/exam.properties
+++ b/src/test/resources/exam.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Disable the default bundles provisioned under pax logging
+pax.exam.logging=none


### PR DESCRIPTION
bump bundle major version to 2.0.0
bump org.apache.sling.auth.core to 2.0.0
bump org.apache.sling.api to 3.0.0
bump slf4j-api to the 2.x version
migrate the javax.servlet references to jakarta.servlet

refactor the test to use the jakarta servlet based apis